### PR TITLE
add GCP security foundations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ GCP whitepapers:
 * https://cloud.google.com/security/overview/whitepaper 
 * https://services.google.com/fh/files/misc/security_whitepapers_march2018.pdf 
 * https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security 
+* https://services.google.com/fh/files/misc/google-cloud-security-foundations-guide.pdf
 
 # Other
 


### PR DESCRIPTION
Adding the GCP security foundations guide, a regularly updated whitepaper of detailed security guidance on GCP.