### PR TITLE
Add Capsule project to Kubernetes list

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,7 @@ Dynamic application security testing (DAST) is a type of application testing (in
 | **HelmSnyk** | [https://github.com/up9inc/mizu](https://github.com/up9inc/mizu) | The Helm plugin for Snyk provides a subcommand for testing the images. |[![GitHub stars](https://img.shields.io/github/stars/up9inc/mizu)](https://github.com/up9inc/mizu/stargazers) | 
 | **Kubewarden** | [https://github.com/orgs/kubewarden/repositories](https://github.com/orgs/kubewarden/repositories) | Policy as code for kubernetes from SUSE. |[![GitHub stars](https://img.shields.io/github/stars/kubewarden/kwctl)](https://github.com/up9inc/kubewarden/kwctl) | 
 | **Kubernetes-sigs BOM** | [https://github.com/kubernetes-sigs/bom](https://img.shields.io/github/stars/kubernetes-sigs/bom) |Kubernetes BOM generator |[![GitHub stars](https://img.shields.io/github/stars/kubernetes-sigs/bom)](https://img.shields.io/github/stars/kubernetes-sigs/bom) | 
-
-  
+| **Capsule** | [https://github.com/clastix/capsule](https://github.com/clastix/capsule) | A multi-tenancy and policy-based framework for Kubernetes |![GitHub stars](https://img.shields.io/github/stars/clastix/capsule) |
 
 ## Containers 
 


### PR DESCRIPTION
Fix #31.
Capsule is a multi-tenancy and policy-based framework for Kubernetes.
It helps companies to prevent cluster sprawl and set up governance to enforce the industry security best practices and meet policy requirements.
It is ready for production (it is used by many companies so far) and has around ~800 stars on Github.