### PR TITLE
Add in Badrobot a Kubernetes Operator Audit Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Dynamic application security testing (DAST) is a type of application testing (in
 | **Kubewarden** | [https://github.com/orgs/kubewarden/repositories](https://github.com/orgs/kubewarden/repositories) | Policy as code for kubernetes from SUSE. |[![GitHub stars](https://img.shields.io/github/stars/kubewarden/kwctl)](https://github.com/up9inc/kubewarden/kwctl) | 
 | **Kubernetes-sigs BOM** | [https://github.com/kubernetes-sigs/bom](https://img.shields.io/github/stars/kubernetes-sigs/bom) |Kubernetes BOM generator |[![GitHub stars](https://img.shields.io/github/stars/kubernetes-sigs/bom)](https://img.shields.io/github/stars/kubernetes-sigs/bom) | 
 | **Capsule** | [https://github.com/clastix/capsule](https://github.com/clastix/capsule) | A multi-tenancy and policy-based framework for Kubernetes |![GitHub stars](https://img.shields.io/github/stars/clastix/capsule) |
+| **Badrobot** | [https://github.com/controlplaneio/badrobot](https://github.com/controlplaneio/badrobot) | Badrobot is a Kubernetes Operator audit tool |![GitHub stars](https://img.shields.io/github/stars/controlplaneio/badrobot) |
 
 ## Containers 
 


### PR DESCRIPTION
Badrobot is a Kubernetes Operator audit tool for Kubernetes Operators.
It statically analyses manifests for high risk configurations such as lack of security restrictions on the deployed controller and the permissions of an associated clusterole. The risk analysis is primarily focussed on the likelihood that a compromised Operator would be able to obtain full cluster permissions.

Currently 2 Releases latest v0.1.2, 5 Contributors, 25 Stars, Last commit 2 days ago.
Apache License 2.0 - https://github.com/controlplaneio/badrobot/blob/master/LICENSE

It is still in the early stages of this development but its every useful as demoed at KubeCon + CloudNativeCon Europe 2022.