### PR TITLE
Overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![stars](https://img.shields.io/github/stars/sottlmarek/DevSecOps?style=for-the-badge)
 ![watchers](https://img.shields.io/github/watchers/sottlmarek/DevSecOps?color=green&style=for-the-badge) ![watchers](https://img.shields.io/github/forks/sottlmarek/DevSecOps?color=orange&style=for-the-badge)
 
-This library contains list of tools and methodologies accompanied with resources. The main goal is to provide engineers a guide through opensource DevSecOps tooling. This repository covers only cyber security in the cloud and the DevSecOps scope.
+This library contains a list of tools and methodologies accompanied with resources. The main goal is to provide engineers a guide through opensource DevSecOps tooling. This repository covers only cyber security in the cloud and the DevSecOps scope.
 
 _Note:_ Currently this is an early version of the library. I recommend PR after first official release. 
 
@@ -47,8 +47,8 @@ If you want to contribute to this library of knowledge please create a proper PR
     * [Chaos engineering](#chaos-engineering)
     * [Infrastructure as Code security](#infrastructure-as-code-security)
     * [Orchestration](#orchestration)
+    * [Other](#other)
 * [Methodologies](#methodologies-whitepapers-and-architecture)
-* [Other](#other)
 * [Further reading and resources](#further-reading-and-resources)
 * [License](#license) 
 
@@ -327,6 +327,15 @@ Event driven security help to drive, automate and execute tasks for security pro
 | **DefectDojo** | [https://github.com/DefectDojo/django-DefectDojo](https://github.com/DefectDojo/django-DefectDojo) | Security orchestration and vulnerability management platform |![DefectDojo](https://img.shields.io/github/stars/DefectDojo/django-DefectDojo?style=for-the-badge) | 
 | **Faraday** | [https://github.com/infobyte/faraday](https://github.com/infobyte/faraday) | Security suite for Security Orchestration, vulnerability management and centralized information |![Faraday](https://img.shields.io/github/stars/infobyte/faraday) |
 
+## Other
+
+Here are the other links and resources that either do not fit in any previous category, or that fit in multiple different categories at a time.
+
+| Name | URL | Description | Meta | 
+| :---------- | :---------- | :---------- | :----------: |
+| **Automated Security Helper (ASH)** | [https://github.com/aws-samples/automated-security-helper](https://github.com/aws-samples/automated-security-helper) | ASH is a one stop shop for security scanners, and does not require any installation. It will identify the different frameworks, and download the relevant, up to date tools. ASH is running on isolated Docker containers, keeping the user environment clean, with a single aggregated report. The following frameworks are supported: Git, Python, Javascript, Cloudformation, Terraform and Jupyter Notebooks.  |![ASH](https://img.shields.io/github/stars/aws-samples/automated-security-helper?style=for-the-badge) | 
+| **Mobile security framework** | [https://github.com/MobSF/Mobile-Security-Framework-MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF) | SAST, DAST and pentesting tool for mobile apps |![MobSF](https://img.shields.io/github/stars/MobSF/Mobile-Security-Framework-MobSF?style=for-the-badge) |
+
 # Methodologies, whitepapers and architecture
 
 List of resources worth investigating: 
@@ -363,15 +372,6 @@ GCP whitepapers:
 * https://services.google.com/fh/files/misc/security_whitepapers_march2018.pdf 
 * https://cloud.google.com/security/encryption-in-transit/application-layer-transport-security 
 * https://services.google.com/fh/files/misc/google-cloud-security-foundations-guide.pdf
-
-# Other
-
-Here are the other links and resources that either do not fit in any previous category, or that fit in multiple different categories at a time.
-
-| Name | URL | Description | Meta | 
-| :---------- | :---------- | :---------- | :----------: |
-| **Automated Security Helper (ASH)** | [https://github.com/aws-samples/automated-security-helper](https://github.com/aws-samples/automated-security-helper) | ASH is a one stop shop for security scanners, and does not require any installation. It will identify the different frameworks, and download the relevant, up to date tools. ASH is running on isolated Docker containers, keeping the user environment clean, with a single aggregated report. The following frameworks are supported: Git, Python, Javascript, Cloudformation, Terraform and Jupyter Notebooks.  |![ASH](https://img.shields.io/github/stars/aws-samples/automated-security-helper?style=for-the-badge) | 
-| **Mobile security framework** | [https://github.com/MobSF/Mobile-Security-Framework-MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF) | SAST, DAST and pentesting tool for mobile apps |![MobSF](https://img.shields.io/github/stars/MobSF/Mobile-Security-Framework-MobSF?style=for-the-badge) |
 
 # Further reading and resources
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you want to contribute to this library of knowledge please create a proper PR
 - [Policy as code](#policy-as-code)
 - [Methodologies](#methodologies-whitepapers-and-architecture)
 - [Other](#other)
+- [Further reading and resources](#further-reading-and-resources)
 - [License](#license) 
 
 # What is DevSecOps
@@ -367,9 +368,12 @@ Here are the other links and resources that either do not fit in any previous ca
 | **Automated Security Helper (ASH)** | [https://github.com/aws-samples/automated-security-helper](https://github.com/aws-samples/automated-security-helper) | ASH is a one stop shop for security scanners, and does not require any installation. It will identify the different frameworks, and download the relevant, up to date tools. ASH is running on isolated Docker containers, keeping the user environment clean, with a single aggregated report. The following frameworks are supported: Git, Python, Javascript, Cloudformation, Terraform and Jupyter Notebooks.  |![ASH](https://img.shields.io/github/stars/aws-samples/automated-security-helper?style=for-the-badge) | 
 | **Mobile security framework** | [https://github.com/MobSF/Mobile-Security-Framework-MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF) | SAST, DAST and pentesting tool for mobile apps |![MobSF](https://img.shields.io/github/stars/MobSF/Mobile-Security-Framework-MobSF?style=for-the-badge) |
 
-Training - https://www.practical-devsecops.com/devsecops-university/ 
+# Further reading and resources
 
-DevSecOps videos - [Hackitect playground](https://www.youtube.com/channel/UCy0S_HftNM7Fy0ksEOUHc-Q)
+To further your learning:
+
+* DevSecOps University Training - https://www.practical-devsecops.com/devsecops-university/ 
+* DevSecOps videos on the [Hackitect playground YouTube channel](https://www.youtube.com/channel/UCy0S_HftNM7Fy0ksEOUHc-Q)
 
 # License
 MIT license

--- a/README.md
+++ b/README.md
@@ -29,23 +29,28 @@ If you want to contribute to this library of knowledge please create a proper PR
 
 # Table of Contents
 
-- [Definition](#what-is-devsecops)
-- [Tooling](#tooling)
-- [Precommit and threat modeling](#pre-commit-time-tools)
-- [SAST](#sast)
-- [DAST](#dast)
-- [Orchestration](#orchestration)
-- [Supply chain and dependencies](#oss-and-dependency-management)
-- [Infrastructure as code](#infrastructure-as-code-security)
-- [Containers security](#containers)
-- [Kubernetes](#kubernetes) 
-- [Cloud](#multi-cloud)
-- [Chaos engineering](#chaos-engineering)
-- [Policy as code](#policy-as-code)
-- [Methodologies](#methodologies-whitepapers-and-architecture)
-- [Other](#other)
-- [Further reading and resources](#further-reading-and-resources)
-- [License](#license) 
+* [Definition](#what-is-devsecops)
+* [Tooling](#tooling)
+    * [Pre-commit time tools and threat modeling](#pre-commit-time-tools)
+    * [Secrets management](#secrets-management)
+    * [OSS dependency management](#oss-dependency-management)
+    * [Supply chain specific tools](#supply-chain-specific-tools)
+    * [SAST](#sast)
+    * [DAST](#dast)
+    * [Continous deployment security](#continous-deployment-security)
+    * [Kubernetes](#kubernetes)
+    * [Containers](#containers)
+    * [Multi-Cloud](#multi-cloud)
+    * [AWS](#aws)
+    * [GCP](#gcp)
+    * [Policy as code](#policy-as-code)
+    * [Chaos engineering](#chaos-engineering)
+    * [Infrastructure as Code security](#infrastructure-as-code-security)
+    * [Orchestration](#orchestration)
+* [Methodologies](#methodologies-whitepapers-and-architecture)
+* [Other](#other)
+* [Further reading and resources](#further-reading-and-resources)
+* [License](#license) 
 
 # What is DevSecOps
 
@@ -62,7 +67,7 @@ Various definitions:
 
 # Tooling
 
-## Pre-commit time tools
+## Pre-commit time tools and threat modeling
 
 In this section you can find lifecycle helpers, pre-commit hook tools for Git and threat modeling tools. Threat modeling tools should be in a specific category of their own. They allow you to simulate and discover potential issues before software development even starts, and then continue during development.
 
@@ -259,7 +264,7 @@ AWS specific DevSecOps tooling. Tools here cover different areas like inventory 
 | **Parliment** | [Parliment](https://github.com/duo-labs/parliament) | Parliament is an AWS IAM linting library | ![IAM linting](https://img.shields.io/github/stars/duo-labs/parliament?style=for-the-badge)| 
 | **Yor** | [Yor](https://github.com/bridgecrewio/yor) | Adds informative and consistent tags across infrastructure-as-code frameworks such as Terraform, CloudFormation, and Serverless | ![Yor](https://img.shields.io/github/stars/bridgecrewio/yor?style=for-the-badge)| 
 
-## Google cloud platform 
+## GCP
 
 GCP specific DevSecOps tooling. Tools here cover different areas like inventory management, misconfiguration scanning or IAM roles and policies review. 
 
@@ -297,7 +302,7 @@ Reading and manifestos: https://principlesofchaos.org/
 | **AWS FIS samples** | [https://github.com/aws-samples/aws-fault-injection-simulator-samples](https://github.com/aws-samples/aws-fault-injection-simulator-samples) | AWS Fault injection simulator samples |![AWS](https://img.shields.io/github/stars/aws-samples/aws-fault-injection-simulator-samples?style=for-the-badge) |
 | **CloudNuke** | [https://github.com/gruntwork-io/cloud-nuke](https://github.com/gruntwork-io/cloud-nuke) | CLI tool to delete all resources in an AWS account |![CloudNuke](https://img.shields.io/github/stars/gruntwork-io/cloud-nuke?style=for-the-badge) |
 
-## Infrastructure as code security 
+## Infrastructure as Code security 
 
 Scanning your infrastructure when it is described in IaC code helps shift-left the security. Many tools offer scanning and providing real-time feedback in IDEs and other editors to cloud engineers. 
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 # Ultimate DevSecOps library
 
-## Contribution rules
-If you want to contribute to this library of knowledge please create proper PR (Pull Request) with description what you are adding following these set of rules: 
-
-* Clear description of PR (which tool, why, number of stars, maturity and topic) 
-* Keep it simple - Fill the description properly
-* Fact over feelings or personal opinions
-* Add source and follow the library style
-* Avoid duplicits - one tool, one topic 
-* Try to make bigger updates then on tool link
-* Currently open-source only
-* Add only active projects 
-* Add only security tools 
-* Report typos as issue not via PR. 
-
-_Note:_ Currently this is an early version of the library. I recommend PR after first official release. 
-
-**DevSecOps library info:** 
+## About
 
 ![stars](https://img.shields.io/github/stars/sottlmarek/DevSecOps?style=for-the-badge)
 ![watchers](https://img.shields.io/github/watchers/sottlmarek/DevSecOps?color=green&style=for-the-badge) ![watchers](https://img.shields.io/github/forks/sottlmarek/DevSecOps?color=orange&style=for-the-badge)
 
-This library contains list of tools and methodologies accompanied with resources. The main goal is to provide to the engineers a guide through opensource DevSecOps tooling. This repository covers only cyber security in the cloud and the DevSecOps scope. 
+This library contains list of tools and methodologies accompanied with resources. The main goal is to provide engineers a guide through opensource DevSecOps tooling. This repository covers only cyber security in the cloud and the DevSecOps scope.
+
+_Note:_ Currently this is an early version of the library. I recommend PR after first official release. 
+
+## Contribution rules
+If you want to contribute to this library of knowledge please create a proper PR (Pull Request) with a description of what you are adding following this set of rules:
+
+* Submit the PR with a clear description 
+    * The description should describe the tool, and why it should be on the list
+    * Add a number of GitHub stars, project maturity, and which topic/category it belongs to
+* The tool itself must be...
+    * Part of a currently active project
+    * Open source
+    * A security tool
+* Add the tool into one of the tables in Markdown
+    * Avoid duplicates - a tool may only be in one category in this library
+    * Keep the description simple and proper
+    * Facts over feelings or personal opinions
+    * Follow the library style
+* If you're changing something, try to make bigger updates while you're at it
+* For typos, create an issue, not a pull request
 
 # Table of Contents
 
@@ -42,8 +46,9 @@ This library contains list of tools and methodologies accompanied with resources
 - [Other](#other)
 - [License](#license) 
 
-# What is DevSecOps 
-DevSecOps focuses on security automation, testing and enforcement during DevOps - Release - SDLC cycles. The whole meaning behind this methodology is connecting together Development, Security and Operations. DevSecOps is methodology providing different methods, techniques and processes backed mainly with tooling focusing on developer / security experience. 
+# What is DevSecOps
+
+DevSecOps focuses on security automation, testing and enforcement during _DevOps - Release - SDLC cycles_. The whole meaning behind this methodology is connecting Development, Security and Operations. DevSecOps is methodology providing different methods, techniques and processes backed mainly by tooling focusing on developer & security experience. 
 
 DevSecOps takes care that security is part of every stage of DevOps loop - Plan, Code, Build, Test, Release, Deploy, Operate, Monitor. 
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Various definitions:
 
 ## Pre-commit time tools
 
-In this section you can find lifecycle helpers, precommit hook tools and threat modeling tools. Threat modeling tools are specific category by themselves allowing you to simulate and discover potential gaps before you start to develop the software or during the process.
+In this section you can find lifecycle helpers, pre-commit hook tools for Git and threat modeling tools. Threat modeling tools should be in a specific category of their own. They allow you to simulate and discover potential issues before software development even starts, and then continue during development.
 
-Modern DevSecOps tools allow using Threat modeling as code or generation of threat models based on the existing code annotations. 
+Modern DevSecOps tools allow you to use threat modeling as code or generation of threat models based on code annotations. 
 
 | Name | URL | Description | Meta | 
 | :---------- | :---------- | :---------- | :----------: |
@@ -86,7 +86,8 @@ Modern DevSecOps tools allow using Threat modeling as code or generation of thre
 | **detect-secrets** | [https://github.com/Yelp/detect-secrets](https://github.com/Yelp/detect-secrets) |  Detects secrets in your codebase |![DevSkim](https://img.shields.io/github/stars/Yelp/detect-secrets?style=for-the-badge)| 
 | **tflint** | [https://github.com/terraform-linters/tflint](https://github.com/terraform-linters/tflint) | A Pluggable Terraform Linter | ![tflint](https://img.shields.io/github/stars/terraform-linters/tflint?style=for-the-badge)|
 
-## Secrets management 
+## Secrets management
+
 Secrets management includes managing, versioning, encryption, discovery, rotating, provisioning of passwords, certificates, configuration values and other types of secrets. 
 
 | Name | URL | Description | Meta | 
@@ -104,9 +105,9 @@ Secrets management includes managing, versioning, encryption, discovery, rotatin
 | **Chef vault** | [https://github.com/chef/chef-vault](https://github.com/chef/chef-vault) |  allows you to encrypt a Chef Data Bag Item |![Chef vault](https://img.shields.io/github/stars/chef/chef-vault?style=for-the-badge)|
 | **Ansible vault** | [Ansible vault docs](https://docs.ansible.com/ansible/latest/cli/ansible-vault.html#ansible-vault) |  Encryption/decryption utility for Ansible data files |![Ansible vault](https://img.shields.io/github/stars/ansible-community/ansible-vault?style=for-the-badge)|
 
-## OSS and Dependency management
+## OSS dependency management
 
-Dependency security testing and analysis is very important part of discovering supply chain attacks. SBOM creation and following dependency scanning (Software composition analysis) is critical part of continuous integration (CI). Data series and data trends tracking should be part of CI tooling. You need to know what you produce and what you consume in context of libraries and packages. 
+Security testing and analysis of open-source dependencies is a very important part of discovering supply chain attacks. SBOM creation and the following dependency scanning (Software composition analysis) is a critical part of Continuous Integration (CI). Data series and data trends tracking should be part of CI tooling. You need to know what you produce and what you consume in the context of libraries and packages. 
 
 | Name | URL | Description | Meta | 
 | :---------- | :---------- | :---------- | :----------: |
@@ -128,7 +129,7 @@ Dependency security testing and analysis is very important part of discovering s
 
 ## Supply chain specific tools 
 
-Supply chain is often the target of attacks. Which libraries you use can have a massive impact on security of the final product (artifacts). CI (continuous integration) must be monitored inside the tasks and jobs in pipeline steps. Integrity checks must be stored out of the system and in ideal case several validation runs with comparison of integrity hashes / or attestation must be performed. 
+The dependency supply chain is often the target of attacks. Which libraries you use can have a massive impact on the security of the final product (artifacts). CI (Continuous Integration) must be monitored inside the tasks and jobs of the pipeline steps. Integrity checks must be stored out of the system, and ideally there should be several validation runs with comparison of integrity hashes, or attestation must be performed. 
 
 | Name | URL | Description | Meta | 
 | :---------- | :---------- | :---------- | :----------: |
@@ -141,7 +142,7 @@ Supply chain is often the target of attacks. Which libraries you use can have a 
 
 ## SAST
 
-Static code review tools working with source code and looking for known patterns and relationships of methods, variables, classes and libraries. SAST works with the raw code and usually not with build packages. 
+Static code review tools work with source code and look for known patterns and relationships of methods, variables, classes and libraries. SAST works with raw code and usually not with built packages. 
 
 | Name | URL | Description | Meta | 
 | :---------- | :---------- | :---------- | :----------: |
@@ -155,13 +156,13 @@ Static code review tools working with source code and looking for known patterns
 | **SonarQube community** | [https://github.com/SonarSource/sonarqube](https://github.com/SonarSource/sonarqube) | Detect security issues in code review with Static Application Security Testing (SAST) |![SonarQube](https://img.shields.io/github/stars/SonarSource/sonarqube?style=for-the-badge) | 
 | **gosec** | [https://github.com/securego/gosec](https://github.com/securego/gosec) | Inspects source code for security problems by scanning the Go AST. |![SonarQube](https://img.shields.io/github/stars/securego/gosec?style=for-the-badge) | 
 
-**Note:** Semgrep is free CLI tool, however some rulesets (https://semgrep.dev/r) are having various licences, some can be free to use and can be commercial.  
+**Note:** Semgrep is free CLI tool, however some rulesets (https://semgrep.dev/r) have different (non-open-source) licences - some are free to use, some are commercial.
 
-OWASP curated list of SAST tools : https://owasp.org/www-community/Source_Code_Analysis_Tools 
+OWASP curated list of SAST tools: https://owasp.org/www-community/Source_Code_Analysis_Tools 
 
 ## DAST
 
-Dynamic application security testing (DAST) is a type of application testing (in most cases web) that checks your application from the outside by active communication and analysis of the responses based on injected inputs. DAST tools rely on inputs and outputs to operate. A DAST tool uses these to check for security problems while the software is actually running and is actively deployed on the server (or serverless function).
+Dynamic application security testing (DAST) is a type of application testing (in most cases web application) that checks your application from the outside by active communication and analysis of the responses based on injected inputs. DAST tools rely on inputs and outputs to operate. A DAST tool uses these to check for security problems while the software is actually running and is actively deployed on the server (even on serverless functions and other forms of serverless code deployment).
 
 | Name | URL | Description | Meta | 
 | :---------- | :---------- | :---------- | :----------: |
@@ -297,7 +298,7 @@ Reading and manifestos: https://principlesofchaos.org/
 
 ## Infrastructure as code security 
 
-Scanning your infrastructure when it is only code helps shift-left the security. Many tools offer in IDE scanning and providing real-time advisory do Cloud engineers. 
+Scanning your infrastructure when it is described in IaC code helps shift-left the security. Many tools offer scanning and providing real-time feedback in IDEs and other editors to cloud engineers. 
 
 | Name | URL | Description | Meta |
 | :---------- | :---------- | :---------- | :----------: |
@@ -359,7 +360,7 @@ GCP whitepapers:
 
 # Other
 
-Here are the other links and resources that do not fit in any previous category. They can meet multiple categories in time or help you in your learning. 
+Here are the other links and resources that either do not fit in any previous category, or that fit in multiple different categories at a time.
 
 | Name | URL | Description | Meta | 
 | :---------- | :---------- | :---------- | :----------: |


### PR DESCRIPTION
* Fixes typos / rewords sentences all across except in the tool descriptions in the table
* Restructures intro and submission rules (separate section for "info" / `#about`)
* Creates a separate section for the other resources (`#further-reading-and-resources`)
* Aligns ToC order, size, and makes text match that of headings