### PR TITLE
Add Legitify

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Here are the other links and resources that do not fit in any previous category.
 | :---------- | :---------- | :---------- | :----------: |
 | **Automated Security Helper (ASH)** | [https://github.com/aws-samples/automated-security-helper](https://github.com/aws-samples/automated-security-helper) | ASH is a one stop shop for security scanners, and does not require any installation. It will identify the different frameworks, and download the relevant, up to date tools. ASH is running on isolated Docker containers, keeping the user environment clean, with a single aggregated report. The following frameworks are supported: Git, Python, Javascript, Cloudformation, Terraform and Jupyter Notebooks.  |![ASH](https://img.shields.io/github/stars/aws-samples/automated-security-helper?style=for-the-badge) | 
 | **Mobile security framework** | [https://github.com/MobSF/Mobile-Security-Framework-MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF) | SAST, DAST and pentesting tool for mobile apps |![MobSF](https://img.shields.io/github/stars/MobSF/Mobile-Security-Framework-MobSF?style=for-the-badge) |
+| **Legitify** | [https://github.com/Legit-Labs/legitify](https://github.com/Legit-Labs/legitify) | Detect and remediate misconfigurations and security risks across all your GitHub and GitLab assets  |![Legitify](https://img.shields.io/github/stars/Legit-Labs/legitify?style=for-the-badge) |
 
 Training - https://www.practical-devsecops.com/devsecops-university/ 
 


### PR DESCRIPTION
Legitify is a tool that can be utilized to assess security configurations in GitHub and GitLab environments.
Examples include misconfiguration of GitHub Actions, not enabling SSO, permissive repository settings, and more.