### PR TITLE
Add nullsec-k8sscan to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Dynamic application security testing (DAST) is a type of application testing (in
 | **Kubernetes Insights** | [https://github.com/turbot/steampipe-mod-kubernetes-insights](https://github.com/turbot/steampipe-mod-kubernetes-insights) | Visualize Kubernetes inventory and permissions through relationship graphs. | [![GitHub stars](https://img.shields.io/github/stars/turbot/steampipe-mod-kubernetes-insights)](https://github.com/turbot/steampipe-mod-kubernetes-insights/stargazers) |
 | **Kubernetes Compliance** | [https://github.com/turbot/steampipe-mod-kubernetes-compliance](https://github.com/turbot/steampipe-mod-kubernetes-compliance) | Check compliance of Kubernetes configurations to security best practices. | [![GitHub stars](https://img.shields.io/github/stars/turbot/steampipe-mod-kubernetes-compliance)](https://github.com/turbot/steampipe-mod-kubernetes-compliance/stargazers) |
 | **trivy-operator** | [https://github.com/aquasecurity/trivy-operator](https://github.com/aquasecurity/trivy-operator) | Kubernetes-native security toolkit. | [![GitHub stars](https://img.shields.io/github/stars/aquasecurity/trivy-operator)](https://github.com/aquasecurity/trivy-operator/stargazers) | 
+| **nullsec-k8sscan** | [https://github.com/bad-antics/nullsec-k8sscan](https://github.com/bad-antics/nullsec-k8sscan) | Kubernetes security scanner for RBAC, network policies, pod security, and secrets management |![nullsec-k8sscan](https://img.shields.io/github/stars/bad-antics/nullsec-k8sscan?style=for-the-badge) |
 
 
 ## Containers 


### PR DESCRIPTION
## Description

Adding [nullsec-k8sscan](https://github.com/bad-antics/nullsec-k8sscan) to the Kubernetes security tools section.

## About nullsec-k8sscan

A Kubernetes security scanner that audits:
- **RBAC policies** - Identifies overly permissive roles and risky bindings
- **Network policies** - Detects missing or misconfigured network segmentation  
- **Pod security** - Checks for privileged containers, host namespaces, capabilities
- **Secrets management** - Finds exposed secrets and insecure configurations

Complements existing tools like KubiScan, Kubeaudit, and kube-bench with focused configuration scanning.

## Checklist
- [x] Clear description
- [x] Active project
- [x] Security tool
- [x] Open source
- [x] Follows library style

Thank you for maintaining this excellent DevSecOps resource!