### PR TITLE
Add mcp-safeguard — security scanner for AI agent MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Static code review tools working with source code and looking for known patterns
 | **Bearer** | [https://github.com/Bearer/bearer](https://github.com/Bearer/bearer) | Detect security issues in various languages (JavaScript/TypeScript, Ruby, Java, PHP...) . |![Safety](https://img.shields.io/github/stars/Bearer/bearer?style=for-the-badge) | 
 | **mobsfscan** | [https://github.com/MobSF/mobsfscan](https://github.com/MobSF/mobsfscan) | Detect security issues in Android and iOS source code (Java/Kotlin and Objective C/Swift)|![Safety](https://img.shields.io/github/stars/MobSF/mobsfscan?style=for-the-badge) |
 
+| **mcp-safeguard** | [https://github.com/SyedAnas01/mcp-safeguard](https://github.com/SyedAnas01/mcp-safeguard) | Security scanner for MCP (Model Context Protocol) servers. Detects prompt injection in tool descriptions, hardcoded credentials, exposed endpoints, and tool poisoning in AI agent infrastructure. `pip install mcp-safeguard` |![mcp-safeguard](https://img.shields.io/github/stars/SyedAnas01/mcp-safeguard?style=for-the-badge) | 
+
 **Note:** Semgrep is free CLI tool, however some rulesets (https://semgrep.dev/r) are having various licences, some can be free to use and can be commercial.  
 
 OWASP curated list of SAST tools : https://owasp.org/www-community/Source_Code_Analysis_Tools 


### PR DESCRIPTION
mcp-safeguard integrates into DevSecOps pipelines to scan MCP servers for security vulnerabilities: prompt injection, credential leaks, exposed endpoints, and tool poisoning. Relevant to teams building AI-integrated applications using Model Context Protocol. `pip install mcp-safeguard` · https://github.com/SyedAnas01/mcp-safeguard