### PR TITLE
Add envault to Secrets management section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Secrets management includes managing, versioning, encryption, discovery, rotatin
 | **Knox** | [https://github.com/pinterest/knox](https://github.com/pinterest/knox) | Knox is a service for storing and rotation of secrets, keys, and passwords used by other services |![Knox](https://img.shields.io/github/stars/Pinterest/Knox?style=for-the-badge)|
 | **Chef vault** | [https://github.com/chef/chef-vault](https://github.com/chef/chef-vault) |  allows you to encrypt a Chef Data Bag Item |![Chef vault](https://img.shields.io/github/stars/chef/chef-vault?style=for-the-badge)|
 | **Ansible vault** | [Ansible vault docs](https://docs.ansible.com/ansible/latest/cli/ansible-vault.html#ansible-vault) |  Encryption/decryption utility for Ansible data files |![Ansible vault](https://img.shields.io/github/stars/ansible-community/ansible-vault?style=for-the-badge)|
+| **envault** | [https://github.com/coding-dev-tools/envault](https://github.com/coding-dev-tools/envault) | CLI for .env secrets management with vault-style encryption, key rotation, and leak detection |![envault](https://img.shields.io/github/stars/coding-dev-tools/envault?style=for-the-badge) |
 
 ## OSS and Dependency management
 


### PR DESCRIPTION
Adds [envault](https://github.com/coding-dev-tools/envault) to the Secrets management section alongside Hashicorp Vault, SOPS, aws-vault, and Ansible vault.

envault is a CLI for .env secrets management with vault-style encryption, key rotation, and leak detection. It fills a niche for developer-focused secrets management at the .env file level - complementary to enterprise vault solutions.

- 189 weekly npm downloads
- Active development with CI passing
- npm: https://www.npmjs.com/package/envault