### PR TITLE
Add proof-of-commitment — behavioral supply chain risk scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Supply chain is often the target of attacks. Which libraries you use can have a 
 | **kritis** | [https://github.com/grafeas/kritis](https://github.com/grafeas/kritis) | Solution for securing your software supply chain for Kubernetes apps |![Kritis](https://img.shields.io/github/stars/grafeas/kritis?style=for-the-badge)|
 | **ratify** | [https://github.com/deislabs/ratify](https://github.com/deislabs/ratify) | Artifact Ratification Framework |![ratify](https://img.shields.io/github/stars/deislabs/ratify?style=for-the-badge)|
 | **chain-bench** | [https://github.com/aquasecurity/chain-bench](https://github.com/aquasecurity/chain-bench) | Supply Chain Audit Tool |![chain-bench](https://img.shields.io/github/stars/aquasecurity/chain-bench?style=for-the-badge)| 
+| **proof-of-commitment** | [https://github.com/piiiico/proof-of-commitment](https://github.com/piiiico/proof-of-commitment) | Behavioral risk scoring for npm, PyPI, Rust, and Go packages — surfaces single-publisher risk, publisher churn, and install-time anomalies that vulnerability scanners miss |![proof-of-commitment](https://img.shields.io/github/stars/piiiico/proof-of-commitment?style=for-the-badge)| 
 
 
 ## SAST


### PR DESCRIPTION
## What this adds

**proof-of-commitment** ([github.com/piiiico/proof-of-commitment](https://github.com/piiiico/proof-of-commitment)) — behavioral risk scoring for npm, PyPI, Rust, and Go packages.

Added to **Supply chain specific tools** section.

## Why it belongs here

Most supply chain tools focus on known CVEs or SBOM generation. proof-of-commitment surfaces a different class of risk: behavioral anomalies that appear *before* a vulnerability is catalogued.

Key signals it scores:
- **Single-publisher risk** — 26 of the top 91 npm packages (>10M weekly downloads) have exactly 1 npm publisher. `npm audit` doesn't surface this.
- **Publisher churn** — sudden ownership changes on high-download packages (as seen in the axios March 2026 attack)
- **Install-time script anomalies** — postinstall scripts added after a long clean history
- **CI/CD provenance gaps** — packages no longer published through trusted pipelines

Available as MCP server (no login required), CLI (`npx proof-of-commitment`), GitHub Action, and web UI at [getcommit.dev](https://getcommit.dev).

## Format

Follows the existing table format used in this section.