### PR TITLE
Add gh-actions-cli to supply chain specific tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Supply chain is often the target of attacks. Which libraries you use can have a 
 | **kritis** | [https://github.com/grafeas/kritis](https://github.com/grafeas/kritis) | Solution for securing your software supply chain for Kubernetes apps |![Kritis](https://img.shields.io/github/stars/grafeas/kritis?style=for-the-badge)|
 | **ratify** | [https://github.com/deislabs/ratify](https://github.com/deislabs/ratify) | Artifact Ratification Framework |![ratify](https://img.shields.io/github/stars/deislabs/ratify?style=for-the-badge)|
 | **chain-bench** | [https://github.com/aquasecurity/chain-bench](https://github.com/aquasecurity/chain-bench) | Supply Chain Audit Tool |![chain-bench](https://img.shields.io/github/stars/aquasecurity/chain-bench?style=for-the-badge)| 
+| **gh-actions-cli** | [https://github.com/wille/gh-actions-cli](https://github.com/wille/gh-actions-cli) | Pin GitHub Actions to commit SHAs, enforce allowed-actions allowlist policies, and safely update pinned actions |![gh-actions-cli](https://img.shields.io/github/stars/wille/gh-actions-cli?style=for-the-badge)|
 
 
 ## SAST


### PR DESCRIPTION
**Tool:** [gh-actions-cli](https://github.com/wille/gh-actions-cli) (`gha`) — Go CLI, MIT licensed, open source, actively developed (v1.1.0 released this week).

**Topic:** GitHub Actions supply chain hardening. The section currently has no tooling for the Actions-pinning problem (cf. the tj-actions/changed-files compromise affecting 23k+ repos).

**Why:** pins every `uses:` ref to a full commit SHA (with a CI gate for unpinned actions), generates and applies GitHub's allowed-actions allowlist policy from what workflows actually use, enables the new `sha_pinning_required` repo setting, and safely updates pinned actions.

**Maturity/stars:** new project (author here — disclosure), small star count so far but complete feature set and active maintenance.