### PR TITLE
feat: add AEGIS (autonomous IDS/IPS) and ENLIL (multi-agent LLM council) with post-quantum signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Network Intrusion Prevention (NIP) is a security mechanism used to detect and pr
 | Name | URL | Description | Meta |
 | :---------- | :---------- | :---------- | :----------: |
 | **CrowdSec** | [https://github.com/crowdsecurity/crowdsec)](https://github.com/crowdsecurity/crowdsec)  |  Crowdsec is an open-source, lightweight software, detecting peers with aggressive behaviours to prevent them from accessing your systems. |![CrowdSec](https://img.shields.io/github/stars/crowdsecurity/crowdsec) |
+| **AEGIS** | [https://github.com/conchaestradamiguelangel-droid/aegis](https://github.com/conchaestradamiguelangel-droid/aegis) | Autonomous self-hosted IDS/IPS with 9 defense layers (C0-C8), ML-DSA-87 post-quantum signed alerts (NIST FIPS 204), honeypot, AMTD, and behavioral ML — GPL-3.0, Docker. | [![GitHub stars](https://img.shields.io/github/stars/conchaestradamiguelangel-droid/aegis?style=flat)](https://github.com/conchaestradamiguelangel-droid/aegis) |
 
 ## Orchestration 
 
@@ -401,6 +402,7 @@ Tools leveraging AI, LLMs, or agentic workflows for security research, analysis,
 | :---------- | :---------- | :---------- | :----------: |
 | **KubeStellar Console** | [https://github.com/kubestellar/console](https://github.com/kubestellar/console) | Open source AI-powered multi-cluster Kubernetes dashboard with Falco, OPA/Gatekeeper, and Kyverno compliance dashboards for security observability across hybrid edge and cloud. CNCF Sandbox project. |![KubeStellar Console](https://img.shields.io/github/stars/kubestellar/console?style=for-the-badge) |
 | **Cynative** | [https://github.com/cynative/cynative](https://github.com/cynative/cynative) | Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only enforced by default | ![cynative](https://img.shields.io/github/stars/cynative/cynative?style=for-the-badge) |
+| **ENLIL** | [https://github.com/conchaestradamiguelangel-droid/enlil](https://github.com/conchaestradamiguelangel-droid/enlil) | Self-hosted multi-agent LLM council: 9 models deliberate in parallel on any query, output signed with ML-DSA-87 post-quantum signatures (NIST FIPS 204). BYOK via OpenRouter, GPL-3.0, Docker. | [![GitHub stars](https://img.shields.io/github/stars/conchaestradamiguelangel-droid/enlil?style=flat)](https://github.com/conchaestradamiguelangel-droid/enlil) |
 
 # Methodologies, whitepapers and architecture
 


### PR DESCRIPTION
## Added two open-source security tools

### AEGIS — Autonomous IDS/IPS with post-quantum signed alerts

Added to **## Network Intrusion Prevention** section.

- Self-hosted IDS/IPS with 9 autonomous defense layers (C0-C8): port scan detection, traffic fingerprinting, honeypot, AMTD (Autonomous Moving Target Defense), behavioral ML, forensic signing
- Every alert is signed with **ML-DSA-87** (NIST FIPS 204) — post-quantum lattice signatures for tamper-proof incident logs
- GPL-3.0, Docker, no telemetry, live at https://aegis-pq.com
- GitHub: https://github.com/conchaestradamiguelangel-droid/aegis

### ENLIL — Self-hosted multi-agent LLM council

Added to **## AI** section.

- Runs up to 9 LLM models in parallel (Claude, DeepSeek, Gemini, Mistral, Qwen, Llama, Grok) via OpenRouter BYOK
- Models deliberate independently — no cross-contamination until synthesis — producing a structured Decree with explicit dissents recorded
- Every Decree signed with **ML-DSA-87** (NIST FIPS 204) for auditable, tamper-proof AI decision records
- GPL-3.0, Docker, BYOK — zero fixed costs, live at https://enlil-council.com/dashboard
- GitHub: https://github.com/conchaestradamiguelangel-droid/enlil

Both tools are actively maintained, GPL-3.0 licensed, and self-hostable via Docker.