### PR TITLE
Add trentclaw to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Tools leveraging AI, LLMs, or agentic workflows for security research, analysis,
 | :---------- | :---------- | :---------- | :----------: |
 | **KubeStellar Console** | [https://github.com/kubestellar/console](https://github.com/kubestellar/console) | Open source AI-powered multi-cluster Kubernetes dashboard with Falco, OPA/Gatekeeper, and Kyverno compliance dashboards for security observability across hybrid edge and cloud. CNCF Sandbox project. |![KubeStellar Console](https://img.shields.io/github/stars/kubestellar/console?style=for-the-badge) |
 | **Cynative** | [https://github.com/cynative/cynative](https://github.com/cynative/cynative) | Agentic security CLI that runs code in a built-in sandbox to research cloud, code and runtime. Read-only enforced by default | ![cynative](https://img.shields.io/github/stars/cynative/cynative?style=for-the-badge) |
+| **trentclaw** | [https://github.com/trnt-ai/trent-openclaw-security-assessment](https://github.com/trnt-ai/trent-openclaw-security-assessment) | Security assessment for OpenClaw agent deployments — flags misconfigurations, risky skills (prompt injection, permission escalation, data exfiltration), and chained attack paths across gateway config, tool permissions, MCP servers, and plugins. |![trentclaw](https://img.shields.io/github/stars/trnt-ai/trent-openclaw-security-assessment?style=for-the-badge) |
 
 # Methodologies, whitepapers and architecture
 


### PR DESCRIPTION
Tool: trentclaw, github.com/trnt-ai/trent-openclaw-security-assessment
Category: AI. Open-source security assessment for OpenClaw agent deployments; flags misconfigurations, risky skills, and chained attack paths.
Open source: Yes — Apache-2.0 client (core detection runs via the Trent AI API).