### PR TITLE
Add qScan (post-quantum crypto SAST scanner) to SAST section

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Static code review tools working with source code and looking for known patterns
 | **Safety** | [https://github.com/pyupio/safety](https://github.com/pyupio/safety) | Checks Python dependencies for known security vulnerabilities . |![Safety](https://img.shields.io/github/stars/pyupio/safety?style=for-the-badge) | 
 | **Bearer** | [https://github.com/Bearer/bearer](https://github.com/Bearer/bearer) | Detect security issues in various languages (JavaScript/TypeScript, Ruby, Java, PHP...) . |![Safety](https://img.shields.io/github/stars/Bearer/bearer?style=for-the-badge) | 
 | **mobsfscan** | [https://github.com/MobSF/mobsfscan](https://github.com/MobSF/mobsfscan) | Detect security issues in Android and iOS source code (Java/Kotlin and Objective C/Swift)|![Safety](https://img.shields.io/github/stars/MobSF/mobsfscan?style=for-the-badge) |
+| **qScan** | [https://github.com/quantakrypto/pqc-tools](https://github.com/quantakrypto/pqc-tools) | SAST scanner that finds quantum-vulnerable classical crypto (RSA/ECDSA/ECDH/DH) across 14 languages; emits CBOM/SBOM/SARIF/OpenVEX |![qScan](https://img.shields.io/github/stars/quantakrypto/pqc-tools?style=for-the-badge) |
 
 **Note:** Semgrep is free CLI tool, however some rulesets (https://semgrep.dev/r) are having various licences, some can be free to use and can be commercial.  
 


### PR DESCRIPTION
Adding one tool to the **SAST** section, following the contribution rules.

**Tool:** qScan (`@quantakrypto/qscan`), part of the [quantakrypto/pqc-tools](https://github.com/quantakrypto/pqc-tools) monorepo.

**What it is:** A static scanner that flags quantum-vulnerable classical cryptography (RSA / (EC)DH / ECDSA / EdDSA — the "harvest now, decrypt later" risk) in source code across 14 languages (JS/TS, Python, Go, Java/Kotlin/Scala, C#, Rust, Ruby, PHP, Elixir, C/C++, Swift, Objective-C, Dart, Solidity). It emits CBOM/SBOM, SARIF, and OpenVEX.

**Why:** The SAST section has no post-quantum / crypto-agility scanner. This covers a distinct class of finding (which algorithms are quantum-vulnerable) rather than the usual injection/misconfig patterns, so it complements the existing entries instead of duplicating one.

**Topic:** SAST (source-code static analysis).

**Meta:**
- License: Apache-2.0 (open source)
- Active: last commit today (2026-07-26)
- Maturity: published on npm (v0.5.0), OpenSSF Best Practices badge, CI GitHub Action, MCP server
- Stars: 9 (new project — disclosing honestly per the rules)

One row added to the SAST table, matching the existing `Name | URL | Description | Meta` format. No other lines touched.
